### PR TITLE
Merge changes

### DIFF
--- a/src/pixiewps.c
+++ b/src/pixiewps.c
@@ -462,6 +462,13 @@ static void empty_pin_hmac(struct global *wps)
 	hmac_sha256(wps->authkey, WPS_AUTHKEY_LEN, NULL, 0, wps->empty_psk);
 }
 
+static char* format_time(time_t t, char* buf30)
+{
+	struct tm ts;
+	strftime(buf30, 30, "%c", gmtime_r(&t, &ts));
+	return buf30;
+}
+
 int main(int argc, char **argv)
 {
 	struct global *wps;
@@ -600,18 +607,14 @@ memory_err:
 					unsigned int cores = hardware_concurrency();
 					struct timeval t_current;
 					gettimeofday(&t_current, 0);
-					time_t r_time;
-					struct tm ts;
 					char buffer[30];
-					r_time = t_current.tv_sec;
-					gmtime_r(&r_time, &ts);
-					strftime(buffer, 30, "%c", &ts);
 					fprintf(stderr, "\n ");
 					printf("Pixiewps %s", LONG_VERSION); fflush(stdout);
 					fprintf(stderr, "\n\n"
 							" [*] System time: %lu (%s UTC)\n"
 							" [*] Number of cores available: %u\n\n",
-							(unsigned long) t_current.tv_sec, buffer, cores == 0 ? 1 : cores);
+							(unsigned long) t_current.tv_sec,
+							format_time(t_current.tv_sec, buffer), cores == 0 ? 1 : cores);
 					free(wps->error);
 					free(wps);
 					return ARG_ERROR;
@@ -1270,16 +1273,13 @@ usage_err:
 
 						#if DEBUG
 						{
-							struct tm ts;
 							char buffer[30];
-							gmtime_r(&wps->start, &ts);
-							strftime(buffer, 30, "%c", &ts);
 							printf("\n [DEBUG] %s:%d:%s(): Start: %10lu (%s UTC)",
-								__FILE__, __LINE__, __func__, (unsigned long) wps->start, buffer);
-							gmtime_r(&wps->end, &ts);
-							strftime(buffer, 30, "%c", &ts);
+								__FILE__, __LINE__, __func__, (unsigned long) wps->start,
+								format_time(wps->start, buffer));
 							printf("\n [DEBUG] %s:%d:%s(): End:   %10lu (%s UTC)",
-								__FILE__, __LINE__, __func__, (unsigned long) wps->end, buffer);
+								__FILE__, __LINE__, __func__, (unsigned long) wps->end,
+								format_time(wps->end, buffer));
 							fflush(stdout);
 						}
 						#endif
@@ -1426,24 +1426,19 @@ usage_err:
 			if (found_p_mode == RTL819x) {
 				if (wps->nonce_seed) {
 					time_t seed_time;
-					struct tm ts;
 					char buffer[30];
 
-					printf("\n [*] Seed N1:  %u", wps->nonce_seed);
 					seed_time = wps->nonce_seed;
-					gmtime_r(&seed_time, &ts);
-					strftime(buffer, 30, "%c", &ts);
-					printf(" (%s UTC)", buffer);
-					printf("\n [*] Seed ES1: %u", wps->s1_seed);
+					printf("\n [*] Seed N1:  %u", (unsigned) seed_time);
+					printf(" (%s UTC)", format_time(seed_time, buffer));
+
 					seed_time = wps->s1_seed;
-					gmtime_r(&seed_time, &ts);
-					strftime(buffer, 30, "%c", &ts);
-					printf(" (%s UTC)", buffer);
-					printf("\n [*] Seed ES2: %u", wps->s2_seed);
+					printf("\n [*] Seed ES1: %u", (unsigned) seed_time);
+					printf(" (%s UTC)", format_time(seed_time, buffer));
+
 					seed_time = wps->s2_seed;
-					gmtime_r(&seed_time, &ts);
-					strftime(buffer, 30, "%c", &ts);
-					printf(" (%s UTC)", buffer);
+					printf("\n [*] Seed ES2: %u", (unsigned) seed_time);
+					printf(" (%s UTC)", format_time(seed_time, buffer));
 				}
 				else {
 					printf("\n [*] Seed N1:  -");

--- a/src/pixiewps.c
+++ b/src/pixiewps.c
@@ -604,7 +604,7 @@ memory_err:
 					struct tm ts;
 					char buffer[30];
 					r_time = t_current.tv_sec;
-					ts = *gmtime(&r_time);
+					gmtime_r(&r_time, &ts);
 					strftime(buffer, 30, "%c", &ts);
 					fprintf(stderr, "\n ");
 					printf("Pixiewps %s", LONG_VERSION); fflush(stdout);
@@ -1272,11 +1272,11 @@ usage_err:
 						{
 							struct tm ts;
 							char buffer[30];
-							ts = *gmtime(&wps->start);
+							gmtime_r(&wps->start, &ts);
 							strftime(buffer, 30, "%c", &ts);
 							printf("\n [DEBUG] %s:%d:%s(): Start: %10lu (%s UTC)",
 								__FILE__, __LINE__, __func__, (unsigned long) wps->start, buffer);
-							ts = *gmtime(&wps->end);
+							gmtime_r(&wps->end, &ts);
 							strftime(buffer, 30, "%c", &ts);
 							printf("\n [DEBUG] %s:%d:%s(): End:   %10lu (%s UTC)",
 								__FILE__, __LINE__, __func__, (unsigned long) wps->end, buffer);
@@ -1431,17 +1431,17 @@ usage_err:
 
 					printf("\n [*] Seed N1:  %u", wps->nonce_seed);
 					seed_time = wps->nonce_seed;
-					ts = *gmtime(&seed_time);
+					gmtime_r(&seed_time, &ts);
 					strftime(buffer, 30, "%c", &ts);
 					printf(" (%s UTC)", buffer);
 					printf("\n [*] Seed ES1: %u", wps->s1_seed);
 					seed_time = wps->s1_seed;
-					ts = *gmtime(&seed_time);
+					gmtime_r(&seed_time, &ts);
 					strftime(buffer, 30, "%c", &ts);
 					printf(" (%s UTC)", buffer);
 					printf("\n [*] Seed ES2: %u", wps->s2_seed);
 					seed_time = wps->s2_seed;
-					ts = *gmtime(&seed_time);
+					gmtime_r(&seed_time, &ts);
 					strftime(buffer, 30, "%c", &ts);
 					printf(" (%s UTC)", buffer);
 				}


### PR DESCRIPTION
## Summary by Sourcery

Introduce a unified time formatting helper and refactor all ad-hoc gmtime/strftime calls to use it for system info, debug logs, and seed output

Enhancements:
- Add format_time helper to centralize UTC time formatting
- Replace manual gmtime and strftime calls in main output, debug sections, and seed logging with format_time